### PR TITLE
fix: fix duplicating folders during CRW theia syncing

### DIFF
--- a/build/scripts/sync.sh
+++ b/build/scripts/sync.sh
@@ -79,9 +79,8 @@ sync_dstheia_to_dsimages() {
     if [[ ${targDir} == "theia-endpoint" ]]; then sourceDir="theia-endpoint-runtime-binary"; fi
     # TODO: should we use --delete?
     echo "Rsync ${SOURCEDIR}/dockerfiles/${sourceDir} to ${TARGETDIR}/devspaces-${targDir}"
-    rsync -azrlt --checksum --exclude-from /tmp/rsync-excludes "${SOURCEDIR}/dockerfiles/${sourceDir}" "${TARGETDIR}/devspaces-${targDir}"
-    # don't need two copies of the Dockerfile, so move from subdir into root
-    mv -f "${TARGETDIR}/devspaces-${targDir}/${sourceDir}/Dockerfile" "${TARGETDIR}/devspaces-${targDir}/Dockerfile"
+    rsync -azrlt --checksum --delete --exclude-from /tmp/rsync-excludes "${SOURCEDIR}/dockerfiles/${sourceDir}/"* "${TARGETDIR}/devspaces-${targDir}/"
+
     # ensure shell scripts are executable
     find "${TARGETDIR}/devspaces-${targDir}" -name "*.sh" -exec chmod +x {} \;
   done


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Sync ds-theia folders properly, so that files will be copied over to midstream/downstream root, skipping the "theia-xyz" subdirectory
### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2996

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
