### PR TITLE
WIP: CRW-3071, standardizing arguments across build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,8 +16,8 @@ set -u
 nodeVersion="14.18.2" # version of node to use for theia containers (aligned to version in ubi base images)
 # see https://catalog.redhat.com/software/containers/ubi8/nodejs-12/5d3fff015a13461f5fb8635a?container-tabs=packages or run
 # podman run -it --rm --entrypoint /bin/bash registry.redhat.io/ubi8/nodejs-12 -c "node -v"
-DS_VERSION="" # must set this via cmdline with --cv, or use --cb to set MIDSTM_BRANCH
-MIDSTM_BRANCH="" # must set this via cmdline with --cb, or use --cv to set DS_VERSION
+DS_VERSION="" # must set this via cmdline with -v, or use -b to set MIDSTM_BRANCH
+MIDSTM_BRANCH="" # must set this via cmdline with -b, or use -v to set DS_VERSION
 SOURCE_BRANCH="master"
 THEIA_BRANCH="master"
 THEIA_GITHUB_REPO="eclipse-theia/theia" # or redhat-developer/eclipse-theia so we can build from a tag instead of a random commit SHA
@@ -43,8 +43,8 @@ See https://github.com/settings/tokens for more information.
 Examples:
   $(if [[ -r ./BUILD_COMMAND ]]; then cat ./BUILD_COMMAND; fi)
 
-  $0 --ctb ${SOURCE_BRANCH} --all --no-cache --no-tests --rmi:tmp --cb devspaces-3.y-rhel-8
-  $0 --ctb ${SOURCE_BRANCH} --all --no-cache --no-tests --rmi:tmp --cv 3.y
+  $0 --ctb ${SOURCE_BRANCH} --all --no-cache --no-tests --rmi:tmp -b devspaces-3.y-rhel-8
+  $0 --ctb ${SOURCE_BRANCH} --all --no-cache --no-tests --rmi:tmp -v 3.y
 
 Options:
   $0 -d      | build theia-dev
@@ -56,8 +56,8 @@ Note that steps are run in the order specified, so always start with -d if neede
 
 Additional flags:
   --ctb      | CHE_THEIA_BRANCH from which to sync into DS; default: ${SOURCE_BRANCH}
-  --cb       | DS_BRANCH from which to compute version of DS to put in Dockerfiles, eg., devspaces-3.y-rhel-8 or ${MIDSTM_BRANCH}
-  --cv       | rather than pull from DS_BRANCH version of redhat-developer/devspaces/dependencies/VERSION file, 
+  -b         | DS_BRANCH from which to compute version of DS to put in Dockerfiles, eg., devspaces-3.y-rhel-8 or ${MIDSTM_BRANCH}
+  -v         | rather than pull from DS_BRANCH version of redhat-developer/devspaces/dependencies/VERSION file, 
              | just set DS_VERSION; default: ${DS_VERSION}
   --tb       | container build arg THEIA_BRANCH from which to get Eclipse Theia sources, default: ${THEIA_BRANCH} [never change this]
   --tgr      | container build arg THEIA_GITHUB_REPO from which to get Eclipse Theia sources, default: ${THEIA_GITHUB_REPO}
@@ -109,8 +109,8 @@ for key in "$@"; do
       '--tb') THEIA_BRANCH="$2"; shift 2;;
       '--tgr') THEIA_GITHUB_REPO="$2"; shift 2;;
       '--tcs') THEIA_COMMIT_SHA="$2"; shift 2;;
-      '--cb')  MIDSTM_BRANCH="$2"; shift 2;;
-      '--cv')  DS_VERSION="$2"; shift 2;;
+      '-b')  MIDSTM_BRANCH="$2"; shift 2;;
+      '-v')  DS_VERSION="$2"; shift 2;;
       '-d') STEPS="${STEPS} bootstrap_ds_theia_dev"; shift 1;;
       '-t') STEPS="${STEPS} bootstrap_ds_theia"; shift 1;;
       '-e'|'-b') STEPS="${STEPS} bootstrap_ds_theia_endpoint_runtime_binary"; shift 1;;
@@ -135,7 +135,7 @@ if [[ ! ${DS_VERSION} ]] && [[ ${MIDSTM_BRANCH} ]]; then
   DS_VERSION=$(curl -sSLo- https://raw.githubusercontent.com/redhat-developer/devspaces/${MIDSTM_BRANCH}/dependencies/VERSION)
 fi
 if [[ ! ${DS_VERSION} ]]; then 
-  echo "Error: must set either --cb devspaces-3.y-rhel-8 or --cv 3.y to define the version of DS Theia to build."
+  echo "Error: must set either -b devspaces-3.y-rhel-8 or -v 3.y to define the version of DS Theia to build."
   usage
 fi
 

--- a/build/scripts/collect-assets.sh
+++ b/build/scripts/collect-assets.sh
@@ -33,12 +33,12 @@ usage () {
 pkgs.devel devspaces-theia-dev checked out. Repeat for theia and theia-endpoint pkgs.devel repos.
 
 Usage:
-  $0 --cb MIDSTM_BRANCH --target /path/to/pkgs.devel/devspaces-theia-dev/ [options]
+  $0 -b MIDSTM_BRANCH --target /path/to/pkgs.devel/devspaces-theia-dev/ [options]
 
 Examples:
-  $0 --cb ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia-dev/      -d --rmi:tmp --ci --commit
-  $0 --cb ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia/          -t --rmi:tmp --ci --commit
-  $0 --cb ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia-endpoint/ -e --rmi:tmp --ci --commit
+  $0 -b ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia-dev/      -d --rmi:tmp --ci --commit
+  $0 -b ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia/          -t --rmi:tmp --ci --commit
+  $0 -b ${usage_branch} --target /path/to/pkgs.devel/devspaces-theia-endpoint/ -e --rmi:tmp --ci --commit
 
 Directory flags:
   --target     | instead of writing assets into current dir $(pwd)/, target a different place
@@ -52,8 +52,8 @@ Architecture flags:
   --platforms \"${PLATFORMS}\" | architectures for which to collect assets
 
 Optional flags:
-  --cb             | DS_BRANCH from which to compute version of DS to put in Dockerfiles, eg., devspaces-3.y-rhel-8 or ${MIDSTM_BRANCH}
-  --cv             | rather than pull from DS_BRANCH version of redhat-developer/devspaces/dependencies/VERSION file, 
+  -b             | DS_BRANCH from which to compute version of DS to put in Dockerfiles, eg., devspaces-3.y-rhel-8 or ${MIDSTM_BRANCH}
+  -v             | rather than pull from DS_BRANCH version of redhat-developer/devspaces/dependencies/VERSION file, 
                    | just set DS_VERSION; default: ${DS_VERSION}
   --nv             | node version to use; default: ${nodeVersion}
   --pr             | if building based on a GH pull request, use 'pr' in tag names instead of 'tmp'
@@ -76,11 +76,11 @@ for key in "$@"; do
   case $key in 
       '-d'|'--theia-dev') ARCHSTEPS="collect_arch_assets_ds_theia_dev"; NOARCHSTEPS="collect_noarch_assets_ds_theia_dev"; shift 1;;
       '-t'|'--theia') ARCHSTEPS="collect_arch_assets_ds_theia"; NOARCHSTEPS="collect_noarch_assets_ds_theia"; shift 1;;
-      '-e'|'-b'|'--theia-endpoint'|'--theia-endpoint-runtime-binary') ARCHSTEPS="collect_arch_assets_ds_theia_endpoint_runtime_binary"; NOARCHSTEPS="collect_noarch_assets_ds_theia_endpoint_runtime_binary"; shift 1;;
+      '-e'|'--theia-endpoint'|'--theia-endpoint-runtime-binary') ARCHSTEPS="collect_arch_assets_ds_theia_endpoint_runtime_binary"; NOARCHSTEPS="collect_noarch_assets_ds_theia_endpoint_runtime_binary"; shift 1;;
+      '-b')  MIDSTM_BRANCH="$2"; shift 2;;
+      '-v')  DS_VERSION="$2"; shift 2;;
       '--target') TARGETDIR="$2"; shift 2;;
       '--platforms') PLATFORMS="$2"; shift 2;;
-      '--cb')  MIDSTM_BRANCH="$2"; shift 2;;
-      '--cv')  DS_VERSION="$2"; shift 2;;
       '--nv') nodeVersion="$2"; shift 2;;
       '--pr') BUILD_TYPE="pr"; shift 1;;
       '--gh') BUILD_TYPE="gh"; shift 1;;
@@ -95,7 +95,7 @@ if [[ ! ${DS_VERSION} ]] && [[ ${MIDSTM_BRANCH} ]]; then
   DS_VERSION=$(curl -sSLo- https://raw.githubusercontent.com/redhat-developer/devspaces/${MIDSTM_BRANCH}/dependencies/VERSION)
 fi
 if [[ ! ${DS_VERSION} ]]; then 
-  echo "[ERROR] Must set either --cb devspaces-3.y-rhel-8 or --cv 3.y to define the version of DS Theia for which to collect assets."; echo
+  echo "[ERROR] Must set either -b devspaces-3.y-rhel-8 or -v 3.y to define the version of DS Theia for which to collect assets."; echo
   usage
 fi
 echo "[INFO] Using MIDSTM_BRANCH = ${MIDSTM_BRANCH} and DS_VERSION = ${DS_VERSION}"

--- a/build/scripts/sync.sh
+++ b/build/scripts/sync.sh
@@ -29,6 +29,8 @@ if [[ $# -lt 4 ]]; then usage; fi
 
 while [[ "$#" -gt 0 ]]; do
   case $1 in
+    '-v') exit 0; shift 1;; #in case something tries to pass in CSV version or branch
+    '-b') exit 0; shift 1;; #
     # paths to use for input and ouput
     '-s') SOURCEDIR="$2"; SOURCEDIR="${SOURCEDIR%/}"; shift 2;;
     '-t') TARGETDIR="$2"; TARGETDIR="${TARGETDIR%/}"; shift 2;;

--- a/get-sources.sh
+++ b/get-sources.sh
@@ -27,16 +27,15 @@ CSV_VERSION=$(curl -sSLo- "https://raw.githubusercontent.com/redhat-developer/de
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in
-		'-d'|'--delete-assets') DELETE_ASSETS=1; exit 0;;  # TODO switch to shift 0 when we have a way to use GH releases for Theia asset files
-		'-a'|'--publish-assets') PUBLISH_ASSETS=1; exit 0;; # TODO switch to shift 0 when we have a way to use GH releases for Theia asset files
-		'-p'|'--pull-assets') PULL_ASSETS=1; shift 0;;
-		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 0;;
-		'-f'|'--force-build') forceBuild=1; shift 0;;
-		'-s'|'--scratch') scratchFlag="--scratch"; shift 0;;
-		'-v') CSV_VERSION="$2"; shift 1;;
-		'-ght') GITHUB_TOKEN="$2"; shift 1;;
+		'-d'|'--delete-assets') exit 0; shift 1;;  # TODO switch to shift 0 when we have a way to use GH releases for Theia asset files
+		'-a'|'--publish-assets') exit 0; shift 1;; # TODO switch to shift 0 when we have a way to use GH releases for Theia asset files
+		'-p'|'--pull-assets') PULL_ASSETS=1; shift 1;;
+		'-n'|'--nobuild') doRhpkgContainerBuild=0; shift 1;;
+		'-f'|'--force-build') forceBuild=1; shift 1;;
+		'-s'|'--scratch') scratchFlag="--scratch"; shift 1;;
+		'-v') CSV_VERSION="$2"; shift 2;;
+		'-ght') GITHUB_TOKEN="$2"; shift 2;;
 	esac
-	shift 1
 done
 
 function log()

--- a/get-sources.sh
+++ b/get-sources.sh
@@ -67,7 +67,7 @@ OLD_SHA="$(git rev-parse --short=4 HEAD)"
 if [[ ${PULL_ASSETS} -eq 1 ]]; then 
   # collect assets. NOTE: target folder must end in theia-dev/, theia/ or theia-endpoint/ to auto-compute what to collect; 
   # otherwise an override flag is needed: -d, --theia-dev, -t, --theia, -e, --theia-endpoint
-  ./build/scripts/collect-assets.sh --cb ${MIDSTM_BRANCH} --target $(pwd)/ --rmi:tmp --ci --commit
+  ./build/scripts/collect-assets.sh -b ${MIDSTM_BRANCH} --target $(pwd)/ --rmi:tmp --ci --commit
 fi
 NEW_SHA="$(git rev-parse --short=4 HEAD)"
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
Updates theia build scripts to use the same arguments as the rest of the DevSpaces scripts (i.e -v for DS_VERSION, -b for MIDSTM_BRANCH) and updates anything calling these to use the new arguments.

WIP for now, will need to be merged alongside changes for other repos.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3071
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
