### PR TITLE
fix: don't try to remove old sync files

### DIFF
--- a/build/scripts/sync.sh
+++ b/build/scripts/sync.sh
@@ -81,9 +81,6 @@ sync_dstheia_to_dsimages() {
     echo "Rsync ${SOURCEDIR}/dockerfiles/${sourceDir} to ${TARGETDIR}/devspaces-${targDir}"
     rsync -azrlt --checksum --delete --exclude-from /tmp/rsync-excludes "${SOURCEDIR}/dockerfiles/${sourceDir}/"* "${TARGETDIR}/devspaces-${targDir}/"
 
-    # CRW-2958 remove duplicate content in theia-*/src folder
-    git rm -fr "${TARGETDIR}/devspaces-${targDir}/${sourceDir}/" || rm -fr "${TARGETDIR}/devspaces-${targDir}/${sourceDir}/"
-
     # ensure shell scripts are executable
     find "${TARGETDIR}/devspaces-${targDir}" -name "*.sh" -exec chmod +x {} \;
   done


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

-->

### What does this PR do?
To avoid unnecessary errors, there should be no removal files from nested "devspaces-*" in midstream (since they don't exist anymore)

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3119

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR (if applicable)
<!-- Please add a matching PR to [the docs repo](https://gitlab.cee.redhat.com/red-hat-developers-documentation/red-hat-devtools) and link that PR to this issue.
Both will be merged at the same time. -->
